### PR TITLE
Fix for arbitrary installation path

### DIFF
--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -53,9 +53,8 @@ function(){
 }
 
 # Add fpath
-_zsh_python_prompt_filename=${0:A}
-_zsh_python_prompt_path=${_zsh_python_prompt_filename%/*}
-fpath=(${_zsh_python_prompt_path}/functions(N-/) ${fpath})
+_zsh_python_prompt_dir=${0:A:h}
+fpath=(${_zsh_python_prompt_dir}/functions(N-/) ${fpath})
 
 # autoload
 autoload -Uz zsh-python-prompt

--- a/zshrc.zsh
+++ b/zshrc.zsh
@@ -53,7 +53,9 @@ function(){
 }
 
 # Add fpath
-fpath=(~/.zsh/plugins/zsh-python-prompt/functions(N-/) ${fpath})
+_zsh_python_prompt_filename=${0:A}
+_zsh_python_prompt_path=${_zsh_python_prompt_filename%/*}
+fpath=(${_zsh_python_prompt_path}/functions(N-/) ${fpath})
 
 # autoload
 autoload -Uz zsh-python-prompt


### PR DESCRIPTION
Just in the case, when we clone not to ~/.zsh/plugins
