### PR TITLE
Use pyenv version-name when python version matches pyenv path.

### DIFF
--- a/functions/zsh-python-prompt-update
+++ b/functions/zsh-python-prompt-update
@@ -43,7 +43,7 @@ function _zsh_python_prompt_pyenv(){
     elif [[ $python_path =~ '/.pyenv/versions/' ]]; then
         pytype=$(echo "$python_path" | sed -e 's%.*\.pyenv/versions/\([^/]*\)/.*%\1%')
         if [[ $pytype == $pyver ]]; then
-            pytype=
+            pytype=$(pyenv version-name)
         fi
     else
         pytype=$python_path


### PR DESCRIPTION
I wanted to still see the pyenv name when the version matches. This seems to happen when the pyenv version is a symbolic link.